### PR TITLE
Add a link to the sunset notice to the top of every page in the 2.7 documentation

### DIFF
--- a/Doc/tools/templates/layout.html
+++ b/Doc/tools/templates/layout.html
@@ -30,7 +30,7 @@
 {% endblock %}
 {% block header %}
     <div class="warning">
-      {% trans %}This version of Python is no longer supported. {% endtrans %} <a href="https://www.python.org/doc/sunset-python-2/">{% trans %}See the sunset notice.{% endtrans %} <a href="https://docs.python.org/">{% trans %}See the documentation for the latest supported version.{% endtrans %}</a>
+      {% trans %}This version of Python is no longer supported.{% endtrans %} <a href="https://www.python.org/doc/sunset-python-2/">{% trans %}See the sunset notice.{% endtrans %} <a href="https://docs.python.org/">{% trans %}See the documentation for the latest supported version.{% endtrans %}</a>
     </div>
     {{ super() }}
 {% endblock %}

--- a/Doc/tools/templates/layout.html
+++ b/Doc/tools/templates/layout.html
@@ -28,6 +28,12 @@
     </style>
     {% endif %}
 {% endblock %}
+{% block document %}
+    <div class="deprecated">
+      {% trans %}Python 2.7 is no longer supported. {% endtrans %} <a href="https://www.python.org/doc/sunset-python-2/">{% trans %}Here's the sunset notice.{% endtrans %}</a>
+    </div>
+    {{ super() }}
+{% endblock %}
 {% block footer %}
     <div class="footer">
     &copy; <a href="{{ pathto('copyright') }}">{% trans %}Copyright{% endtrans %}</a> {{ copyright|e }}.

--- a/Doc/tools/templates/layout.html
+++ b/Doc/tools/templates/layout.html
@@ -28,9 +28,9 @@
     </style>
     {% endif %}
 {% endblock %}
-{% block document %}
-    <div class="deprecated">
-      {% trans %}Python 2.7 is no longer supported. {% endtrans %} <a href="https://www.python.org/doc/sunset-python-2/">{% trans %}Here's the sunset notice.{% endtrans %}</a>
+{% block header %}
+    <div class="warning">
+      {% trans %}Python 2.7 is no longer supported. {% endtrans %} <a href="https://www.python.org/doc/sunset-python-2/">{% trans %}See the sunset notice.{% endtrans %} <a href="https://docs.python.org/">{% trans %}See the documentation for the latest supported version.{% endtrans %}</a>
     </div>
     {{ super() }}
 {% endblock %}

--- a/Doc/tools/templates/layout.html
+++ b/Doc/tools/templates/layout.html
@@ -30,7 +30,7 @@
 {% endblock %}
 {% block header %}
     <div class="warning">
-      {% trans %}Python 2.7 is no longer supported. {% endtrans %} <a href="https://www.python.org/doc/sunset-python-2/">{% trans %}See the sunset notice.{% endtrans %} <a href="https://docs.python.org/">{% trans %}See the documentation for the latest supported version.{% endtrans %}</a>
+      {% trans %}This version of Python is no longer supported. {% endtrans %} <a href="https://www.python.org/doc/sunset-python-2/">{% trans %}See the sunset notice.{% endtrans %} <a href="https://docs.python.org/">{% trans %}See the documentation for the latest supported version.{% endtrans %}</a>
     </div>
     {{ super() }}
 {% endblock %}


### PR DESCRIPTION
This branch illustrates a way of addressing one item mentioned in https://github.com/python/steering-council/issues/3: "adding a banner to end of life versions that clearly indicates that the specified version is no longer receiving security updates, and potentially also linking to the latest version."

This branch overrides the `header` block (defined in the [Sphinx basic layout](https://github.com/sphinx-doc/sphinx/blob/3.x/sphinx/themes/basic/layout.html#L176)) to include a new `<div>` tag containing stand-in copy with links to the [Python 2 sunset document](https://www.python.org/doc/sunset-python-2/) and to [docs.python.org](https://docs.python.org/), which redirects to the documentation for the latest release. This tag can be moved somewhat within the document by overriding a different block. Either `header`, `content`, or `document` will work; I chose `header` because the resulting document looks the most like [the Django documentation](https://docs.djangoproject.com/en/1.10/ref/django-admin/) given as an example.

The `warning` CSS class (defined in [the Sphinx 'classic' CSS file](https://github.com/sphinx-doc/sphinx/blob/3.x/sphinx/themes/classic/static/classic.css_t#L266)) is used to distinguish the sunset message from the rest of the document. Alternately, a new class could be defined in [this project's custom CSS file](https://github.com/python/cpython/tree/2.7/Doc/tools/static) specifically for a sunset notification.

Since each release of Python has a separate branch and a separate documentation build, this change would need to be backported to the other 2.x branches.